### PR TITLE
Fix NameError: name 'README' is not defined

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,11 @@ setup(
     name='wagtail_embed_videos',
     version='0.0.5',
     description='Embed Videos for Wagtail CMS.',
-    long_description=README,
+    long_description=(
+        'Simple app that works similar to wagtailimages,' 
+        'but for embedding YouTube and Vimeo videos and music from SoundCloud. '
+        'It's an integration of django-embed-video.'
+        )
     author='Diogo Marques',
     author_email='doriva.marques.29@gmail.com',
     maintainer='Diogo Marques',


### PR DESCRIPTION
Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-g43cf6a2-build/setup.py", line 9, in <module>
        long_description=README,
    NameError: name 'README' is not defined
