### PR TITLE
Fix more warnings bitch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setup(
     url='https://github.com/infoportugal/wagtail-embedvideos',
     packages=['wagtail_embed_videos', 'wagtail_embed_videos.views'],
     package_data={'wagtail_embed_videos': ['static/wagtail_embed_videos/js/*.js']},
-    requires=['django(>=1.7)', 'wagtail(>=1.0)', 'django-embed-video(>=1.0)'],
-    install_requires=['wagtail', 'django-embed-video'],
+    install_requires=['django>=1.7', 'wagtail>=1.0', 'django-embed-video>=1.0'],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',


### PR DESCRIPTION
Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-3z1z17xu-build/setup.py", line 37, in <module>
        license='New BSD',
      File "/usr/lib/python3.4/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/media/tulipan/Datos/Proyectos/Trabajo/CCCT/lib/python3.4/site-packages/setuptools/dist.py", line 272, in __init__
        _Distribution.__init__(self,attrs)
      File "/usr/lib/python3.4/distutils/dist.py", line 252, in **init**
        getattr(self.metadata, "set_" + key)(val)
      File "/usr/lib/python3.4/distutils/dist.py", line 1209, in set_requires
        distutils.versionpredicate.VersionPredicate(v)
      File "/usr/lib/python3.4/distutils/versionpredicate.py", line 114, in **init**
        raise ValueError("expected parenthesized list: %r" % paren)
    ValueError: expected parenthesized list: '-embed-video(>=1.0)'
