### PR TITLE
Updating embed video button feature in editor

### DIFF
--- a/wagtail_embed_videos/rich_text.py
+++ b/wagtail_embed_videos/rich_text.py
@@ -1,0 +1,118 @@
+from draftjs_exporter.dom import DOM
+
+from wagtail.admin.rich_text.converters import editor_html
+from wagtail.admin.rich_text.converters.contentstate_models import Entity
+from wagtail.admin.rich_text.converters.html_to_contentstate import AtomicBlockEntityElementHandler
+
+from wagtail_embed_videos import get_embed_video_model
+
+
+# Front-end conversion
+
+def video_embedtype_handler(attrs):
+    """
+    Given a dict of attributes from the <embed> tag, return the real HTML
+    representation for use on the front-end.
+    """
+    Video = get_embed_video_model()
+    try:
+        video = Video.objects.get(id=attrs['id'])
+    except Video.DoesNotExist:
+        return "<video>"
+
+    video_format = get_video_format(attrs['format'])
+    return video_format.video_to_html(video, attrs.get('alt', ''))
+
+
+# hallo.js / editor-html conversion
+
+class VideoEmbedHandler:
+    """
+    VideoEmbedHandler will be invoked whenever we encounter an element in HTML content
+    with an attribute of data-embedtype="video". The resulting element in the database
+    representation will be:
+    <embed embedtype="video" id="42" format="thumb" alt="some custom alt text">
+    """
+
+    @staticmethod
+    def get_db_attributes(tag):
+        """
+        Given a tag that we've identified as an video embed (because it has a
+        data-embedtype="video" attribute), return a dict of the attributes we should
+        have on the resulting <embed> element.
+        """
+        return {
+            'id': tag['data-id'],
+            'format': tag['data-format'],
+            'alt': tag['data-alt'],
+        }
+
+    @staticmethod
+    def expand_db_attributes(attrs):
+        """
+        Given a dict of attributes from the <embed> tag, return the real HTML
+        representation for use within the editor.
+        """
+        Video = get_embed_video_model()
+        try:
+            video = Video.objects.get(id=attrs['id'])
+        except Video.DoesNotExist:
+            return "<video>"
+
+        video_format = get_video_format(attrs['format'])  # TODO: What's about this?
+
+        return video_format.video_to_editor_html(video, attrs.get('alt', ''))
+
+
+EditorHTMLEmbedVideoConversionRule = [
+    editor_html.EmbedTypeRule('video', VideoEmbedHandler)
+]
+
+
+# draft.js / contentstate conversion
+
+def video_entity(props):
+    """
+    Helper to construct elements of the form
+    <embed alt="Right-aligned video" embedtype="video" format="right" id="1"/>
+    when converting from contentstate data
+    """
+    return DOM.create_element('embed', {
+        'embedtype': 'video',
+        'format': props.get('format'),
+        'id': props.get('id'),
+        'alt': props.get('alt'),
+    })
+
+
+class VideoElementHandler(AtomicBlockEntityElementHandler):
+    """
+    Rule for building an video entity when converting from database representation
+    to contentstate
+    """
+
+    def create_entity(self, name, attrs, state, contentstate):
+        Video = get_embed_video_model()
+        try:
+            video = Video.objects.get(id=attrs['id'])
+            video_format = get_video_format(attrs['format'])
+            src = video.url
+        except Video.DoesNotExist:
+            src = ''
+
+        return Entity('VIDEO', 'IMMUTABLE', {
+            'id': attrs['id'],
+            'src': src,
+            'alt': attrs.get('alt'),
+            'format': attrs['format']
+        })
+
+
+ContentstateEmbedVideoConversionRule = {
+    'from_database_format': {
+        'embed[embedtype="video"]': VideoElementHandler(),
+    },
+    'to_database_format': {
+        'entity_decorators': {'VIDEO': video_entity}
+    }
+}

--- a/wagtail_embed_videos/static/wagtail_embed_videos/js/embed-video-chooser.js
+++ b/wagtail_embed_videos/static/wagtail_embed_videos/js/embed-video-chooser.js
@@ -11,8 +11,10 @@ function createEmbedVideoChooser(id) {
                 'embedVideoChosen': function(embedVideoData) {
                     input.val(embedVideoData.id);
                     previewEmbedVideo.attr({
-                        'src': embedVideoData.preview.url,
-                        'alt': embedVideoData.title
+                        src: embedVideoData.preview.url,
+                        width: embedVideoData.preview.width,
+                        height: embedVideoData.preview.height,
+                        alt: embedVideoData.title
                     });
                     chooserElement.removeClass('blank');
                     editLink.attr('href', embedVideoData.edit_link);
@@ -21,7 +23,7 @@ function createEmbedVideoChooser(id) {
         });
     });
 
-    $('.action-clear', chooserElement).click(function() {
+    $('.action-clear', chooserElement).on('click', function() {
         input.val('');
         chooserElement.addClass('blank');
     });

--- a/wagtail_embed_videos/static/wagtail_embed_videos/js/hallo-plugins/hallo-embedvideo.js
+++ b/wagtail_embed_videos/static/wagtail_embed_videos/js/hallo-plugins/hallo-embedvideo.js
@@ -1,6 +1,6 @@
 (function() {
     (function($) {
-        return $.widget('IKS.hallowembedvideo', {
+        return $.widget('IKS.halloembedvideo', {
             options: {
                 uuid: '',
                 editable: null

--- a/wagtail_embed_videos/static/wagtail_embed_videos/js/hallo-plugins/hallo-embedvideo.js
+++ b/wagtail_embed_videos/static/wagtail_embed_videos/js/hallo-plugins/hallo-embedvideo.js
@@ -1,0 +1,47 @@
+(function() {
+    (function($) {
+        return $.widget('IKS.hallowembedvideo', {
+            options: {
+                uuid: '',
+                editable: null
+            },
+            populateToolbar: function(toolbar) {
+                var button, widget;
+
+                widget = this;
+                button = $('<span class="' + this.widgetName + '"></span>');
+                button.hallobutton({
+                    uuid: this.options.uuid,
+                    editable: this.options.editable,
+                    label: 'Videos',
+                    icon: 'icon-media',
+                    command: null
+                });
+                toolbar.append(button);
+                return button.on('click', function(event) {
+                    var insertionPoint, lastSelection;
+
+                    lastSelection = widget.options.editable.getSelection();
+                    insertionPoint = $(lastSelection.endContainer).parentsUntil('.halloeditor').last();
+                    return ModalWorkflow({
+                        url: window.chooserUrls.embedVideoChooser + '?select_format=true',
+                        responses: {
+                            embedVideoChosen: function(embedVideoData) {
+                                var elem;
+
+                                elem = $(embedVideoData.html).get(0);
+                                lastSelection.insertNode(elem);
+                                if (elem.getAttribute('contenteditable') === 'false') {
+                                    insertRichTextDeleteControl(elem);
+                                }
+
+                                return widget.options.editable.element.trigger('change');
+                            }
+                        }
+                    });
+                });
+            }
+        });
+    })(jQuery);
+
+}).call(this);

--- a/wagtail_embed_videos/static/wagtail_embed_videos/js/hallo-plugins/hallo-embedvideos.js
+++ b/wagtail_embed_videos/static/wagtail_embed_videos/js/hallo-plugins/hallo-embedvideos.js
@@ -1,6 +1,6 @@
 (function() {
     (function($) {
-        return $.widget('IKS.halloembedvideo', {
+        return $.widget('IKS.halloembedvideos', {
             options: {
                 uuid: '',
                 editable: null

--- a/wagtail_embed_videos/wagtail_hooks.py
+++ b/wagtail_embed_videos/wagtail_hooks.py
@@ -74,11 +74,11 @@ def editor_js():
         '\n', '<script src="{0}"></script>',
         ((filename,) for filename in js_files)
     )
-
     return js_includes + format_html(
         """
         <script>
             window.chooserUrls.embedVideoChooser = '{0}';
+            registerHalloPlugin('halloembedvideos');
         </script>
         """,
         reverse('wagtail_embed_videos:chooser')
@@ -86,7 +86,7 @@ def editor_js():
 
 
 @hooks.register('register_rich_text_features')
-def register_video_feature(features):
+def register_embed_videos_feature(features):
     # define a handler for converting <embed embedtype="image"> tags into frontend HTML
     features.register_embed_type('video', video_embedtype_handler)
 
@@ -94,8 +94,8 @@ def register_video_feature(features):
     features.register_editor_plugin(
         'hallo', 'video',
         HalloPlugin(
-            name='halloembedvideo',
-            js=['wagtail_embed_videos/js/hallo-plugins/hallo-embedvideo.js'],
+            name='halloembedvideos',
+            js=['wagtail_embed_videos/js/hallo-plugins/hallo-embedvideos.js'],
         )
     )
 


### PR DESCRIPTION
Integrating this package in `Draftail`.

Ok, the first problem here is how works this package.

It works using other third party package: `django-embed-videos`.

It handle the video creation since url, and make a thumbnail image. This package generate this thumbnail as a `wagtail` image.

So, i'm not sure about how integrate this functionality with `draftail`, which is the correctly configuration?